### PR TITLE
Add support for color temperature

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,7 @@ const transformData = data => {
         manufacturer: data['3']['0'],
         state: data['3311'][0]['5850'],
         brightness: Math.round(data['3311'][0]['5851'] / 254 * 100),
+        colorTemperature: data['3311'][0]['5711'],
         colorX: data['3311'][0]['5709'],
         colorY: data['3311'][0]['5710'],
     }
@@ -300,6 +301,14 @@ class TradfriAccessory {
             .on('get', this.getBrightness.bind(this))
             .on('set', this.setBrightness.bind(this));
 
+        if (typeof this.device.colorTemperature !== 'undefined') {
+            lightbulbService
+                .getCharacteristic(Characteristic.ColorTemperature)
+                .on('get', this.getColorTemp.bind(this))
+                .on('set', this.setColorTemp.bind(this));
+	} else {
+	    this.log.debug("Could not find color Temperature for " + this.device.name);		
+	}
         if (typeof this.device.colorX !== 'undefined') {
             lightbulbService
                 .getCharacteristic(Characteristic.Hue)
@@ -383,6 +392,26 @@ class TradfriAccessory {
         }).catch(err => {
             callback(null);
         });
+    }
+
+    getColorTemp(callback) {
+        callback(null, this.device.colorTemperature);
+    }
+
+    setColorTemp(temp, callback) {
+        const coap = this.platform.coap;
+	this.device.colorTemperature = temp;
+	this.log.info("Set color temp to " + temp);
+	const data = {
+	    "3311": [{
+		"5711": temp
+	    }]
+	};
+	coap.put(`15001/${ this.device.id }`, data).then(() => {
+	    callback(null);
+	}).catch(err => {
+	    callback(null);
+	});
     }
 
     getHue(callback) {


### PR DESCRIPTION
This PR adds basic support for setting the color temperature (color temperature wheel) from Homekit. Conveniently, the Tradfri COAP appears to directly support setting the color temperature via attribute `5711`.  It also uses mired units, as provided by Homekit's [HMCharacteristicTypeColorTemperature](https://developer.apple.com/documentation/homekit/hmcharacteristictypecolortemperature) capability, so no conversion is necessary in this case.